### PR TITLE
Fix `websiteName` data key

### DIFF
--- a/examples/single_content_type/README.md
+++ b/examples/single_content_type/README.md
@@ -39,7 +39,7 @@ In [config.rb](./config.rb) you will find the above cited configuration block. L
 <ul>
   <% data.links.link.each do |id, link| %>
     <li>
-      <a href="<%= link["url"] %>"><%= link["website_name"] %></a>
+      <a href="<%= link["url"] %>"><%= link["websiteName"] %></a>
     </li>
   <% end %>
 </ul>

--- a/examples/single_content_type/source/index.html.erb
+++ b/examples/single_content_type/source/index.html.erb
@@ -10,7 +10,7 @@ title: Welcome to Middleman
       <ul>
         <% data.links.link.each do |id, link| %>
           <li>
-            <a href="<%= link["url"] %>"><%= link["website_name"] %></a>
+            <a href="<%= link["url"] %>"><%= link["websiteName"] %></a>
           </li>
         <% end %>
       </ul>


### PR DESCRIPTION
When I got set up with the “Single Content Type” example, the links were not rendering their names within the anchor tags.

The data that was pulled down from Contentful is this:

``` yaml
:id: 1g0qfuEDey2SYYYKEa8WMY
:websiteName: Github
:url: https://www.github.com
```

But the layout was referencing `website_name`, rather than `websiteName`. This PR fixes that both in the layout, as well as the mention of it in the README.
